### PR TITLE
Test/setup and drop database

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,6 @@ First, clone this repository. Then:
 > bin/rails server # Start the server at localhost:3000
 ```
 
-Hello!
+## Running tests
+
+Before running tests, it might be worth running `rails db:setup`. This will ensure the test database and tables are created on your local machine and are up to date with the latest migration files.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,13 +7,6 @@ require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
-require 'rake'
-
-rake = Rake.application
-rake.init
-rake.load_rakefile
-rake['db:setup'].invoke
-
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -61,8 +54,4 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-
-  config.after(:suite) do
-    rake['db:drop'].invoke
-  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,13 @@ require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+require 'rake'
+
+rake = Rake.application
+rake.init
+rake.load_rakefile
+rake['db:setup'].invoke
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -54,4 +61,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.after(:suite) do
+    rake['db:drop'].invoke
+  end
 end


### PR DESCRIPTION
We've added automatic create and drop of db to the rails_helper.rb file: please download the repo and check it all works ok for you! db:create should run all migration files and create the schemas accordingly. db:drop should drop the database after the suite of tests has been run. If you find an error, please let us know